### PR TITLE
fix and simplify the example

### DIFF
--- a/index.html
+++ b/index.html
@@ -3542,7 +3542,7 @@ dictionary Ed448Params : Algorithm {
 
       // Perform the key agreement.
       const alice_x25519_params = { name: 'X25519', public: bob_public_key };
-      const alice_shared_key = await crypto.subtle.deriveKey(x25519_params, alice_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
+      const alice_shared_key = await crypto.subtle.deriveKey(alice_x25519_params, alice_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
 
       // Derive a symmetric key from the result.
       const salt = crypto.getRandomValues(new Uint8Array(32));


### PR DESCRIPTION
1. fixes `x25519_params` to be `alice_x25519_params`
2. improves readability by using e.g. `bob.privateKey` instead of a separate `bob_private_key` variable


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-secure-curves/pull/9.html" title="Last updated on Mar 31, 2022, 3:18 PM UTC (addf168)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/9/b39307d...panva:addf168.html" title="Last updated on Mar 31, 2022, 3:18 PM UTC (addf168)">Diff</a>