### PR TITLE
Reject small order elements on key import and signature verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,13 +159,6 @@
               </p>
             </li>
             <li>
-              <p>
-                If |secret| is the all-zero value,
-                then [= exception/throw =] a {{OperationError}}.
-                This check must be performed in constant-time, as per [[RFC7748]] Section 6.1.
-              </p>
-            </li>
-            <li>
               <dl class="switch">
                 <dt>If |length| is null:</dt>
                 <dd>Return |secret|</dd>
@@ -1014,13 +1007,6 @@
                 [[RFC7748]] Section 5 with |key| as the X448 private key |k|
                 and the X448 public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a>
                 internal slot of |publicKey| as the X448 public key |u|.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |secret| is the all-zero value,
-                then [= exception/throw =] a {{OperationError}}.
-                This check must be performed in constant-time, as per [[RFC7748]] Section 6.2.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1894,6 +1894,13 @@
             </li>
             <li>
               <p>
+                If the point R, encoded in the first half of |signature|,
+                represents a small-order element on the Elliptic Curve of Ed25519,
+                [= exception/throw =] a {{DataError}}.
+              </p>
+            </li>
+            <li>
+              <p>
                 Return |result|.
               </p>
             </li>
@@ -2790,6 +2797,13 @@ dictionary Ed448Params : Algorithm {
               <p>
                 Let |result| be a boolean with the value `true` if the signature is valid
                 and the value `false` otherwise.
+              </p>
+            </li>
+            <li>
+              <p>
+                If the point R, encoded in the first half of |signature|,
+                represents a small-order element on the Elliptic Curve of Ed448,
+                [= exception/throw =] a {{DataError}}.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -687,6 +687,12 @@
             </li>
             <li>
               <p>
+                If the key data of |key| represents a small-order element
+                on the Elliptic Curve of X25519, [= exception/throw =] a {{DataError}}.
+              </p>
+            </li>
+            <li>
+              <p>
                 Return |key|
               </p>
             </li>
@@ -1539,6 +1545,12 @@
             </li>
             <li>
               <p>
+                If the key data of |key| represents a small-order element
+                on the Elliptic Curve of X448, [= exception/throw =] a {{DataError}}.
+              </p>
+            </li>
+            <li>
+              <p>
                 Return |key|
               </p>
             </li>
@@ -2385,6 +2397,12 @@
                   </p>
                 </dd>
               </dl>
+            </li>
+            <li>
+              <p>
+                If the key data of |key| represents a small-order element
+                on the Elliptic Curve of Ed25519, [= exception/throw =] a {{DataError}}.
+              </p>
             </li>
             <li>
               <p>
@@ -3279,6 +3297,12 @@ dictionary Ed448Params : Algorithm {
                   </p>
                 </dd>
               </dl>
+            </li>
+            <li>
+              <p>
+                If the key data of |key| represents a small-order element on
+                the Elliptic Curve of Ed448, [= exception/throw =] a {{DataError}}.
+              </p>
             </li>
             <li>
               <p>


### PR DESCRIPTION
Reject small order elements when importing keys, and reject small order elements during EdDSA signature verification.

Also, no longer require checking for all-zero derived keys in X25519 and X448, as this is redundant with checking for small-order elements.

Fixes #10.

Cc @panva and @littledivy, since you have experimental implementations, it would be great if you could review this. I believe many crypto libraries already check for small order elements, but this aims to specify when exactly we should reject them.

(There's also an open question on whether we should list the small order elements in the spec explicitly? Or perhaps that's unnecessary / too low level. It may be worth having them in the tests, though.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/pull/13.html" title="Last updated on Nov 18, 2022, 3:04 PM UTC (090e05a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/13/d41f001...090e05a.html" title="Last updated on Nov 18, 2022, 3:04 PM UTC (090e05a)">Diff</a>