### PR TITLE
Reject invalid EdDSA points on key import

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,13 +159,6 @@
               </p>
             </li>
             <li>
-              <p>
-                If |secret| is the all-zero value,
-                then [= exception/throw =] a {{OperationError}}.
-                This check must be performed in constant-time, as per [[RFC7748]] Section 6.1.
-              </p>
-            </li>
-            <li>
               <dl class="switch">
                 <dt>If |length| is null:</dt>
                 <dd>Return |secret|</dd>
@@ -1014,13 +1007,6 @@
                 [[RFC7748]] Section 5 with |key| as the X448 private key |k|
                 and the X448 public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a>
                 internal slot of |publicKey| as the X448 public key |u|.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |secret| is the all-zero value,
-                then [= exception/throw =] a {{OperationError}}.
-                This check must be performed in constant-time, as per [[RFC7748]] Section 6.2.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1894,6 +1894,13 @@
             </li>
             <li>
               <p>
+                If the point R, encoded in the first half of |signature|,
+                represents a small-order element on the Elliptic Curve of Ed25519,
+                [= exception/throw =] a {{DataError}}.
+              </p>
+            </li>
+            <li>
+              <p>
                 Return |result|.
               </p>
             </li>
@@ -2790,6 +2797,13 @@ dictionary Ed448Params : Algorithm {
               <p>
                 Let |result| be a boolean with the value `true` if the signature is valid
                 and the value `false` otherwise.
+              </p>
+            </li>
+            <li>
+              <p>
+                If the point R, encoded in the first half of |signature|,
+                represents a small-order element on the Elliptic Curve of Ed448,
+                [= exception/throw =] a {{DataError}}.
               </p>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -687,6 +687,12 @@
             </li>
             <li>
               <p>
+                If the key data of |key| represents a small-order element
+                on the Elliptic Curve of X25519, [= exception/throw =] a {{DataError}}.
+              </p>
+            </li>
+            <li>
+              <p>
                 Return |key|
               </p>
             </li>
@@ -1539,6 +1545,12 @@
             </li>
             <li>
               <p>
+                If the key data of |key| represents a small-order element
+                on the Elliptic Curve of X448, [= exception/throw =] a {{DataError}}.
+              </p>
+            </li>
+            <li>
+              <p>
                 Return |key|
               </p>
             </li>
@@ -2385,6 +2397,12 @@
                   </p>
                 </dd>
               </dl>
+            </li>
+            <li>
+              <p>
+                If the key data of |key| represents a small-order element
+                on the Elliptic Curve of Ed25519, [= exception/throw =] a {{DataError}}.
+              </p>
             </li>
             <li>
               <p>
@@ -3279,6 +3297,12 @@ dictionary Ed448Params : Algorithm {
                   </p>
                 </dd>
               </dl>
+            </li>
+            <li>
+              <p>
+                If the key data of |key| represents a small-order element on
+                the Elliptic Curve of Ed448, [= exception/throw =] a {{DataError}}.
+              </p>
             </li>
             <li>
               <p>

--- a/index.html
+++ b/index.html
@@ -2393,7 +2393,7 @@
             </li>
             <li>
               <p>
-                If the key data of |key| represents a small-order element
+                If the key data of |key| represents an invalid point or a small-order element
                 on the Elliptic Curve of Ed25519, [= exception/throw =] a {{DataError}}.
               </p>
             </li>
@@ -3300,8 +3300,8 @@ dictionary Ed448Params : Algorithm {
             </li>
             <li>
               <p>
-                If the key data of |key| represents a small-order element on
-                the Elliptic Curve of Ed448, [= exception/throw =] a {{DataError}}.
+                If the key data of |key| represents an invalid point or a small-order element
+                on the Elliptic Curve of Ed448, [= exception/throw =] a {{DataError}}.
               </p>
             </li>
             <li>


### PR DESCRIPTION
(This PR is on top of #13. See 96fd46d19acbe8509801075e595f4e782f497ec7 for the actual change.)

Check for invalid points during EdDSA key import (instead of allowing the key to be imported and then returning false for any verifications). This is equivalent to the ECDSA checks already done in Web Crypto in various places ("If the public/private key value is not a valid point on the Elliptic Curve identified by the namedCurve member of normalizedAlgorithm throw a DataError").


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/pull/17.html" title="Last updated on Nov 18, 2022, 3:11 PM UTC (96fd46d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/17/d41f001...96fd46d.html" title="Last updated on Nov 18, 2022, 3:11 PM UTC (96fd46d)">Diff</a>