### PR TITLE
Consider signatures with invalid or small-order elements invalid

### DIFF
--- a/index.html
+++ b/index.html
@@ -1869,6 +1869,19 @@
             </li>
             <li>
               <p>
+                If the key data of |key| represents an invalid point or a small-order element
+                on the Elliptic Curve of Ed25519, return `false`.
+              </p>
+            </li>
+            <li>
+              <p>
+                If the point R, encoded in the first half of |signature|,
+                represents an invalid point or a small-order element
+                on the Elliptic Curve of Ed25519, return `false`.
+              </p>
+            </li>
+            <li>
+              <p>
                 Perform the Ed25519 verification steps, as specified in [[RFC8032]],
                 Section 5.1.7, on the |signature|, with |message| as |M|,
                 using the Ed25519 public key associated with |key|.
@@ -2758,6 +2771,19 @@ dictionary Ed448Params : Algorithm {
               <p>
                 If |context| has a length greater than 255 bytes,
                 then [= exception/throw =] an {{OperationError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                If the key data of |key| represents an invalid point or a small-order element
+                on the Elliptic Curve of Ed448, return `false`.
+              </p>
+            </li>
+            <li>
+              <p>
+                If the point R, encoded in the first half of |signature|,
+                represents an invalid point or a small-order element
+                on the Elliptic Curve of Ed448, return `false`.
               </p>
             </li>
             <li>


### PR DESCRIPTION
When verifying an Ed25519 or Ed448 signature, if the public key or the first half of the signature (`R`) is an invalid or small-order element, return false.

Resolves #10; replaces #13 and #17.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/pull/21.html" title="Last updated on Jun 21, 2023, 8:44 AM UTC (d4c0252)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/21/0874265...d4c0252.html" title="Last updated on Jun 21, 2023, 8:44 AM UTC (d4c0252)">Diff</a>