### PR TITLE
Remove JWK "alg" field

### DIFF
--- a/index.html
+++ b/index.html
@@ -3610,8 +3610,7 @@ dictionary Ed448Params : Algorithm {
           <td>
 <pre class=js>
 { kty: "OKP",
-  crv: "Ed25519",
-  alg: "EdDSA" }
+  crv: "Ed25519" }
 </pre>
           </td>
           <td>
@@ -3624,8 +3623,7 @@ dictionary Ed448Params : Algorithm {
           <td>
 <pre class=js>
 { kty: "OKP",
-  crv: "Ed448",
-  alg: "EdDSA" }
+  crv: "Ed448" }
 </pre>
           </td>
           <td>

--- a/index.html
+++ b/index.html
@@ -2243,14 +2243,6 @@
                     </li>
                     <li>
                       <p>
-                        If the {{JsonWebKey/alg}} field of |jwk| is present and is
-                        not "`EdDSA`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
                         If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                         not "`sig`",
                         then [= exception/throw =] a
@@ -2541,12 +2533,6 @@
                       <p>
                         Set the `kty` attribute of |jwk| to
                         "`OKP`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `alg` attribute of |jwk| to
-                        "`EdDSA`".
                       </p>
                     </li>
                     <li>
@@ -3150,14 +3136,6 @@ dictionary Ed448Params : Algorithm {
                     </li>
                     <li>
                       <p>
-                        If the {{JsonWebKey/alg}} field of |jwk| is present and is
-                        not "`EdDSA`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
                         If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                         not "`sig`",
                         then [= exception/throw =] a
@@ -3448,12 +3426,6 @@ dictionary Ed448Params : Algorithm {
                       <p>
                         Set the `kty` attribute of |jwk| to
                         "`OKP`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `alg` attribute of |jwk| to
-                        "`EdDSA`".
                       </p>
                     </li>
                     <li>


### PR DESCRIPTION
The `alg` field is not required and might change in the future, see https://www.ietf.org/archive/id/draft-jones-jose-fully-specified-algorithms-00.html.

Fixes #23, reverts #3 and #4.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/pull/24.html" title="Last updated on Aug 30, 2023, 11:05 AM UTC (07a7b38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/24/36c0f23...07a7b38.html" title="Last updated on Aug 30, 2023, 11:05 AM UTC (07a7b38)">Diff</a>