### PR TITLE
Require cofactorless (unbatched) verification equation for EdDSA

### DIFF
--- a/index.html
+++ b/index.html
@@ -1883,7 +1883,8 @@
             <li>
               <p>
                 Perform the Ed25519 verification steps, as specified in [[RFC8032]],
-                Section 5.1.7, on the |signature|, with |message| as |M|,
+                Section 5.1.7, using the cofactorless (unbatched) equation,
+                `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|,
                 using the Ed25519 public key associated with |key|.
               </p>
             </li>
@@ -2775,7 +2776,8 @@ dictionary Ed448Params : Algorithm {
             <li>
               <p>
                 Perform the Ed448 verification steps, as specified in [[RFC8032]],
-                Section 5.2.7, on the |signature|, with |message| as |M|
+                Section 5.2.7, using the cofactorless (unbatched) equation,
+                `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|
                 and |context| as |C|,
                 using the Ed448 public key associated with |key|.
               </p>


### PR DESCRIPTION
Resolve #19 by mandating the use of the cofactorless (unbatched) verification equation in Ed25519 and Ed448.

According to https://github.com/WICG/webcrypto-secure-curves/issues/19#issuecomment-1806275293 and https://github.com/web-platform-tests/wpt/pull/43751#issuecomment-1932230269, this is already the current behavior of OpenSSL, BoringSSL, and Apple's CryptoKit. Hopefully this is true for other implementations as well, but let me know if there are any objections, of course.

Additionally, since Web Crypto does not have an API for batch signature verification, there seems to be no reason to use the cofactored (batched) equation.

By mandating one of the two equations, we reduce the risk of interoperability failures, as well as the risk of this (potential) difference being used to fingerprint implementations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/pull/25.html" title="Last updated on Feb 8, 2024, 8:49 PM UTC (3f752f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/25/c9eaaac...3f752f3.html" title="Last updated on Feb 8, 2024, 8:49 PM UTC (3f752f3)">Diff</a>