### PR TITLE
Document open issue around randomized signatures

### DIFF
--- a/index.html
+++ b/index.html
@@ -1845,6 +1845,11 @@
                 Section 5.1.6, with |message| as |M|,
                 using the Ed25519 private key associated with |key|.
               </p>
+              <p class="issue" data-number="28">
+                Some implementations may (wish to) generate randomized signatures
+                as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
+                instead of deterministic signatures as per [[RFC8032]].
+              </p>
             </li>
             <li>
               <p>
@@ -2723,6 +2728,11 @@ dictionary Ed448Params : Algorithm {
                 Section 5.2.6, with |message| as |M|
                 and |context| as |C|,
                 using the Ed448 private key associated with |key|.
+              </p>
+              <p class="issue" data-number="28">
+                Some implementations may (wish to) generate randomized signatures
+                as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
+                instead of deterministic signatures as per [[RFC8032]].
               </p>
             </li>
             <li>


### PR DESCRIPTION
Document [issue 28](https://github.com/WICG/webcrypto-secure-curves/issues/28) in the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/pull/30.html" title="Last updated on Oct 15, 2024, 10:27 AM UTC (28747cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/30/067671c...28747cd.html" title="Last updated on Oct 15, 2024, 10:27 AM UTC (28747cd)">Diff</a>