### PR TITLE
remove curve 25519 and add sections for individual operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Secure Curves in the Web Cryptography API
 
-This repository contains a proposal to add support for [Curve25519 and
-Curve448](https://tools.ietf.org/html/rfc7748) in the Web Cryptography API.
+This repository contains a proposal to add support for [Curve448](https://tools.ietf.org/html/rfc7748) in the Web Cryptography API.
 
 There is an [explainer](./explainer.md) and a [draft specification](https://WICG.github.io/webcrypto-secure-curves/).
 
@@ -9,3 +8,5 @@ See the [implementation status](https://github.com/WICG/webcrypto-secure-curves/
 
 Acknowledgement: this proposal was based on [a previous proposal by Qingsi Wang
 to include Curve25519 in WebCrypto](https://github.com/tQsW/webcrypto-curve25519).
+
+Note: Curve25519 has already been added to [Web Cryptography](https://w3c.github.io/webcrypto/)

--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
 <body>
   <section id="abstract">
     <p>
-      This specification defines a number of algorithms for the [[webcrypto | Web Cryptography API]],
-      namely X25519 and X448 [[RFC7748]], and Ed25519 and Ed448 [[RFC8032]].
+      This specification defines a number of algorithms for the [[[webcrypto | Web Cryptography API]]],
+      namely X448 [[RFC7748]] and Ed448 [[RFC8032]].
     </p>
   </section>
   <section id="sotd">
@@ -55,880 +55,21 @@
       the [[webcrypto | Web Cryptography API]], namely key agreement using X25519 and X448 [[RFC7748]], and
       signing and verifying using Ed25519 and Ed448 [[RFC8032]].
     </p>
+    <p>
+      Note: This introduction does not reflect the fact that Curve25519 has already been
+      added to [[[webcrypto | Web Cryptography API]]].
+    </p>
   </section>
   <section id="specification-conventions">
     <h2>Specification Conventions</h3>
     <p>
-      This specification follows the <a data-cite="WebCryptoAPI#algorithm-conventions">conventions</a>
+      This specification follows the <a data-cite="webcrypto#algorithm-conventions">conventions</a>
       laid out in Section 18.3 of [[webcrypto]]. None of the algorithms defined here
       are required to be implemented, but if a conforming User Agent implements an
       algorithm, it MUST implement all of the supported operations specified in this
-      document, and must perform the steps to <a data-cite="WebCryptoAPI#concept-define-an-algorithm">define an algorithm</a>
+      document, and must perform the steps to <a data-cite="webcrypto#concept-define-an-algorithm">define an algorithm</a>
       specified in section 18.4.3 of [[webcrypto]] for each of the supported operations.
     </p>
-  </section>
-
-  <section id="x25519">
-    <h3>X25519</h3>
-    <section id="x25519-description" class="informative">
-      <h4>Description</h4>
-      <p>
-        The "`X25519`" algorithm identifier is used to perform
-        key agreement using the X25519 algorithm specified in
-        [[RFC7748]].
-      </p>
-    </section>
-    <section id="x25519-registration">
-      <h4>Registration</h4>
-      <p>
-        The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
-        for this algorithm is "`X25519`".
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>deriveBits</td>
-            <td>{{EcdhKeyDeriveParams}}</td>
-            <td><a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a></td>
-          </tr>
-          <tr>
-            <td>generateKey</td>
-            <td>None</td>
-            <td>{{CryptoKeyPair}}</td>
-          </tr>
-          <tr>
-            <td>importKey</td>
-            <td>None</td>
-            <td>{{CryptoKey}}</td>
-          </tr>
-          <tr>
-            <td>exportKey</td>
-            <td>None</td>
-            <td>object</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section id="x25519-operations">
-      <h4>Operations</h4>
-      <dl>
-        <dt>Derive Bits</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |publicKey| be the
-                {{EcdhKeyDeriveParams/public}} member of
-                |normalizedAlgorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the {{KeyAlgorithm/name}} attribute of
-                the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
-                |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
-                |key|, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |secret| be the result of performing the X25519 function specified in
-                [[RFC7748]] Section 5 with |key| as the X25519 private key |k|
-                and the X25519 public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a>
-                internal slot of |publicKey| as the X25519 public key |u|.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |secret| is the all-zero value,
-                then [= exception/throw =] a {{OperationError}}.
-                This check must be performed in constant-time, as per [[RFC7748]] Section 6.1.
-              </p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |length| is null:</dt>
-                <dd>Return |secret|</dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <dl class="switch">
-                    <dt>
-                      If the length of |secret| in bits is less than
-                      |length|:
-                    </dt>
-                    <dd>
-                      [= exception/throw =] an
-                      {{OperationError}}.
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      Return an <a data-cite="WebCryptoAPI#octet-string-containing">octet string containing</a> the first |length| bits of |secret|.
-                    </dd>
-                  </dl>
-                </dd>
-              </dl>
-            </li>
-          </ol>
-        </dd>
-        <dt>Generate Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                If |usages| contains an entry which is not
-                "`deriveKey`" or "`deriveBits`"
-                then [= exception/throw =] a
-                {{SyntaxError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Generate an X25519 key pair, with the private key being 32 random bytes,
-                and the public key being `X25519(a, 9)`,
-                as defined in [[RFC7748]], section 6.1.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |algorithm| be a new {{KeyAlgorithm}} object.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{KeyAlgorithm/name}} attribute of
-                |algorithm| to "`X25519`".
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |publicKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the public key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |publicKey| to "`public`"
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |publicKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |publicKey| to true.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |publicKey| to be the empty list.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |privateKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the private key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |privateKey| to {{KeyType/"private"}}
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |privateKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |privateKey| to |extractable|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |privateKey| to be the
-                <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a> of
-                |usages| and `[ "deriveKey", "deriveBits" ]`.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |result| be a new {{CryptoKeyPair}}
-                dictionary.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/publicKey}} attribute
-                of |result| to be |publicKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/privateKey}} attribute
-                of |result| to be |privateKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Return the result of converting |result| to an ECMAScript Object, as
-                defined by [[WebIDL]].
-              </p>
-            </li>
-          </ol>
-        </dd>
-
-        <dt>Import Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>Let |keyData| be the key data to be imported.</p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| is not empty
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |spki| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `algorithm` AlgorithmIdentifier field of |spki| is
-                        not equal to the `id-X25519`
-                        object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the `algorithm`
-                        AlgorithmIdentifier field of |spki| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |publicKey| be the X25519 public key identified by
-                        the `subjectPublicKey` field of |spki|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents |publicKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains an entry which is not
-                        "`deriveKey`" or "`deriveBits`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |privateKeyInfo| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurs while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                        |privateKeyInfo| is not equal to the
-                        `id-X25519` object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                        of |privateKeyInfo| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
-                        algorithm, with |data| as the `privateKey` field
-                        of |privateKeyInfo|, |structure| as the ASN.1
-                        `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents the X25519 private key identified by |curvePrivateKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to {{KeyType/"private"}}
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <dl class="switch">
-                        <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                        <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                        <dt>Otherwise:</dt>
-                        <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/d}} field is present and if |usages|
-                        contains an entry which is not
-                        "`deriveKey`" or "`deriveBits`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/d}} field is not present and if |usages| is not
-                        empty
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/kty}} field of |jwk| is not
-                        "`OKP`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/crv}} field of |jwk| is not
-                        "`X25519`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
-                        and is not equal to "`enc`" then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                        is invalid according to the requirements of JSON Web
-                        Key [[JWK]], or it does not contain all of the specified |usages|
-                        values,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/ext}} field of |jwk| is present and
-                        has the value false and |extractable| is true,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK private key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                X25519 private key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"private"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK public key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                X25519 public key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"public"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| is not empty
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the <a data-cite="webcrypto#dfn-length-in-bits">length in bits</a> of |data| is not 256 then [= exception/throw =] a {{DataError}}.
-                      </p>
-                    </li>                    
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and that represents |data|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |key|
-              </p>
-            </li>
-          </ol>
-        </dd>
-
-        <dt>Export Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                Let |key| be the {{CryptoKey}} to be
-                exported.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
-                cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-              </p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `subjectPublicKeyInfo`
-                        ASN.1 structure defined in [[RFC5280]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |algorithm| field to an
-                            `AlgorithmIdentifier` ASN.1 type with the following
-                            properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-X25519` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |subjectPublicKey| field to |keyData|.
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `privateKeyInfo`
-                        ASN.1 structure defined in [[RFC5208]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |version| field to `0`.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKeyAlgorithm| field to a
-                            `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                            following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-X25519` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKey| field to the result of DER-encoding
-                            a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                            X25519 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
-                            |key|
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        Let |jwk| be a new {{JsonWebKey}}
-                        dictionary.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `kty` attribute of |jwk| to
-                        "`OKP`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `crv` attribute of |jwk| to
-                        "`X25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{JsonWebKey/x}} attribute of |jwk| according to the
-                        definition in Section 2 of [[RFC8037]].
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>
-                          If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                          of |key| is {{KeyType/"private"}}
-                        </dt>
-                        <dd>
-                          Set the {{JsonWebKey/d}} attribute of |jwk| according to the
-                          definition in Section 2 of [[RFC8037]].
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
-                        of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be the result of converting |jwk|
-                        to an ECMAScript Object, as defined by [[WebIDL]].
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>
-                  If |format| is {{KeyFormat/"raw"}}:
-                </dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a> representing the X25519
-                        public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
-                        |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |result|.
-              </p>
-            </li>
-          </ol>
-        </dd>
-      </dl>
-    </section>
   </section>
 
   <section id="x448">
@@ -944,22 +85,22 @@
     <section id="x448-registration">
       <h4>Registration</h4>
       <p>
-        The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
+        The <a data-cite="webcrypto#recognized-algorithm-name">recognized algorithm name</a>
         for this algorithm is "`X448`".
       </p>
       <table>
         <thead>
           <tr>
-            <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
+            <th><a data-cite="webcrypto#supported-operations">Operation</a></th>
+            <th><a data-cite="webcrypto#algorithm-specific-params">Parameters</a></th>
+            <th><a data-cite="webcrypto#algorithm-result">Result</a></th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>deriveBits</td>
             <td>{{EcdhKeyDeriveParams}}</td>
-            <td><a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a></td>
+            <td><a data-cite="webcrypto#dfn-octet-string">octet string</a></td>
           </tr>
           <tr>
             <td>generateKey</td>
@@ -982,1706 +123,814 @@
 
     <section id="x448-operations">
       <h4>Operations</h4>
-      <dl>
-        <dt>Derive Bits</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |publicKey| be the
-                {{EcdhKeyDeriveParams/public}} member of
-                |normalizedAlgorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the {{KeyAlgorithm/name}} attribute of
-                the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
-                |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
-                |key|, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |secret| be the result of performing the X448 function specified in
-                [[RFC7748]] Section 5 with |key| as the X448 private key |k|
-                and the X448 public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a>
-                internal slot of |publicKey| as the X448 public key |u|.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |secret| is the all-zero value,
-                then [= exception/throw =] a {{OperationError}}.
-                This check must be performed in constant-time, as per [[RFC7748]] Section 6.2.
-              </p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |length| is null:</dt>
-                <dd>Return |secret|</dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <dl class="switch">
-                    <dt>
-                      If the length of |secret| in bits is less than
-                      |length|:
-                    </dt>
-                    <dd>
-                      [= exception/throw =] an
-                      {{OperationError}}.
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      Return an <a data-cite="WebCryptoAPI#octet-string-containing">octet string containing</a> the first |length| bits of |secret|.
-                    </dd>
-                  </dl>
-                </dd>
-              </dl>
-            </li>
-          </ol>
-        </dd>
-        <dt>Generate Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                If |usages| contains an entry which is not
-                "`deriveKey`" or "`deriveBits`"
-                then [= exception/throw =] a
-                {{SyntaxError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Generate an X448 key pair, with the private key being 56 random bytes,
-                and the public key being `X448(a, 5)`,
-                as defined in [[RFC7748]], section 6.2.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |algorithm| be a new {{KeyAlgorithm}} object.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{KeyAlgorithm/name}} attribute of
-                |algorithm| to "`X448`".
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |publicKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the public key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |publicKey| to "`public`"
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |publicKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |publicKey| to true.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |publicKey| to be the empty list.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |privateKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the private key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |privateKey| to {{KeyType/"private"}}
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |privateKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |privateKey| to |extractable|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |privateKey| to be the
-                <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a> of
-                |usages| and `[ "deriveKey", "deriveBits" ]`.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |result| be a new {{CryptoKeyPair}}
-                dictionary.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/publicKey}} attribute
-                of |result| to be |publicKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/privateKey}} attribute
-                of |result| to be |privateKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Return the result of converting |result| to an ECMAScript Object, as
-                defined by [[WebIDL]].
-              </p>
-            </li>
-          </ol>
-        </dd>
 
-        <dt>Import Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>Let |keyData| be the key data to be imported.</p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| is not empty
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |spki| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `algorithm` AlgorithmIdentifier field of |spki| is
-                        not equal to the `id-X448`
-                        object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the `algorithm`
-                        AlgorithmIdentifier field of |spki| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |publicKey| be the X448 public key identified by
-                        the `subjectPublicKey` field of |spki|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents |publicKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains an entry which is not
-                        "`deriveKey`" or "`deriveBits`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |privateKeyInfo| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurs while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                        |privateKeyInfo| is not equal to the
-                        `id-X448` object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                        of |privateKeyInfo| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
-                        algorithm, with |data| as the `privateKey` field
-                        of |privateKeyInfo|, |structure| as the ASN.1
-                        `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents the X448 private key identified by |curvePrivateKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to {{KeyType/"private"}}
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <dl class="switch">
-                        <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                        <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                        <dt>Otherwise:</dt>
-                        <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/d}} field is present and if |usages|
-                        contains an entry which is not
-                        "`deriveKey`" or "`deriveBits`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/d}} field is not present and if |usages| is not
-                        empty
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/kty}} field of |jwk| is not
-                        "`OKP`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/crv}} field of |jwk| is not
-                        "`X448`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
-                        and is not equal to "`enc`" then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                        is invalid according to the requirements of JSON Web
-                        Key [[JWK]], or it does not contain all of the specified |usages|
-                        values,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/ext}} field of |jwk| is present and
-                        has the value false and |extractable| is true,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK private key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                X448 private key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"private"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK public key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                X448 public key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"public"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| is not empty
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the <a data-cite="webcrypto#dfn-length-in-bits">length in bits</a> of |data| is not 448 then [= exception/throw =] a {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`X448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and that represents |data|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |key|
-              </p>
-            </li>
-          </ol>
-        </dd>
+      <section id="x448-operations-derive-bits">
+        <h5>Derive Bits</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |publicKey| be the
+              {{EcdhKeyDeriveParams/public}} member of
+              |normalizedAlgorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the {{KeyAlgorithm/name}} attribute of
+              the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
+              |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
+              |key|, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |secret| be the result of performing the X448 function specified in
+              [[RFC7748]] Section 5 with |key| as the X448 private key |k|
+              and the X448 public key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">[[\handle]]</a>
+              internal slot of |publicKey| as the X448 public key |u|.
+            </p>
+          </li>
+          <li>
+            <p>
+              If |secret| is the all-zero value,
+              then [= exception/throw =] a {{OperationError}}.
+              This check must be performed in constant-time, as per [[RFC7748]] Section 6.2.
+            </p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |length| is null:</dt>
+              <dd>Return |secret|</dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <dl class="switch">
+                  <dt>
+                    If the length of |secret| in bits is less than
+                    |length|:
+                  </dt>
+                  <dd>
+                    [= exception/throw =] an
+                    {{OperationError}}.
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    Return an <a data-cite="webcrypto#octet-string-containing">octet string containing</a> the first |length| bits of |secret|.
+                  </dd>
+                </dl>
+              </dd>
+            </dl>
+          </li>
+        </ol>
+      </section>
+      <section id="x448-operations-generate-key">
+        <h5>Generate Key</h5>
+        <ol>
+          <li>
+            <p>
+              If |usages| contains an entry which is not
+              "`deriveKey`" or "`deriveBits`"
+              then [= exception/throw =] a
+              {{SyntaxError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Generate an X448 key pair, with the private key being 56 random bytes,
+              and the public key being `X448(a, 5)`,
+              as defined in [[RFC7748]], section 6.2.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |algorithm| be a new {{KeyAlgorithm}} object.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{KeyAlgorithm/name}} attribute of
+              |algorithm| to "`X448`".
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |publicKey| be a new {{CryptoKey}} associated with the
+              [= relevant global object =]
+              of `this` [[HTML]], and
+              representing the public key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |publicKey| to "`public`"
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+              slot of |publicKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+              slot of |publicKey| to true.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+              |publicKey| to be the empty list.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |privateKey| be a new {{CryptoKey}} associated with the
+              [= relevant global object =]
+              of `this` [[HTML]], and
+              representing the private key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |privateKey| to {{KeyType/"private"}}
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+              slot of |privateKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+              slot of |privateKey| to |extractable|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+              |privateKey| to be the
+              <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a> of
+              |usages| and `[ "deriveKey", "deriveBits" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{CryptoKeyPair}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/publicKey}} attribute
+              of |result| to be |publicKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/privateKey}} attribute
+              of |result| to be |privateKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return the result of converting |result| to an ECMAScript Object, as
+              defined by [[WebIDL]].
+            </p>
+          </li>
+        </ol>
+      </section>
 
-        <dt>Export Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                Let |key| be the {{CryptoKey}} to be
-                exported.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
-                cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-              </p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `subjectPublicKeyInfo`
-                        ASN.1 structure defined in [[RFC5280]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |algorithm| field to an
-                            `AlgorithmIdentifier` ASN.1 type with the following
-                            properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-X448` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |subjectPublicKey| field to |keyData|.
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `privateKeyInfo`
-                        ASN.1 structure defined in [[RFC5208]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |version| field to `0`.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKeyAlgorithm| field to a
-                            `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                            following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-X448` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKey| field to the result of DER-encoding
-                            a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                            X448 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
-                            |key|
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        Let |jwk| be a new {{JsonWebKey}}
-                        dictionary.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `kty` attribute of |jwk| to
-                        "`OKP`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `crv` attribute of |jwk| to
-                        "`X448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+      <section id="x448-operations-import-key">
+        <h5>Import Key</h5>
+        <ol>
+          <li>
+            <p>Let |keyData| be the key data to be imported.</p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| is not empty
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |spki| be the result of running the
+                      <a data-cite="webcrypto#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                      algorithm over |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurred while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `algorithm` object identifier field of the
+                      `algorithm` AlgorithmIdentifier field of |spki| is
+                      not equal to the `id-X448`
+                      object identifier defined in [[RFC8410]],
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `parameters` field of the `algorithm`
+                      AlgorithmIdentifier field of |spki| is present,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |publicKey| be the X448 public key identified by
+                      the `subjectPublicKey` field of |spki|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and
+                      that represents |publicKey|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| to "`public`"
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`X448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains an entry which is not
+                      "`deriveKey`" or "`deriveBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |privateKeyInfo| be the result of running the
+                      <a data-cite="webcrypto#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
+                      algorithm over |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurs while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `algorithm` object identifier field of the
+                      `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                      |privateKeyInfo| is not equal to the
+                      `id-X448` object identifier defined in [[RFC8410]],
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `parameters` field of the
+                      `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                      of |privateKeyInfo| is present,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |curvePrivateKey| be the result of performing the <a data-cite="webcrypto#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
+                      algorithm, with |data| as the `privateKey` field
+                      of |privateKeyInfo|, |structure| as the ASN.1
+                      `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurred while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and
+                      that represents the X448 private key identified by |curvePrivateKey|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| to {{KeyType/"private"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`X448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <dl class="switch">
+                      <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                      <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                      <dt>Otherwise:</dt>
+                      <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/d}} field is present and if |usages|
+                      contains an entry which is not
+                      "`deriveKey`" or "`deriveBits`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/d}} field is not present and if |usages| is not
+                      empty
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/kty}} field of |jwk| is not
+                      "`OKP`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/crv}} field of |jwk| is not
+                      "`X448`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                      and is not equal to "`enc`" then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                      is invalid according to the requirements of JSON Web
+                      Key [[JWK]], or it does not contain all of the specified |usages|
+                      values,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/ext}} field of |jwk| is present and
+                      has the value false and |extractable| is true,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If |jwk| does not meet the requirements of
+                              the JWK private key format described in Section 2
+                              of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              X448 private key identified by interpreting
+                              |jwk| according to Section 2 of [[RFC8037]].
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a>
+                              internal slot of |Key| to {{KeyType/"private"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If |jwk| does not meet the requirements of
+                              the JWK public key format described in Section 2
+                              of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              X448 public key identified by interpreting
+                              |jwk| according to Section 2 of [[RFC8037]].
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a>
+                              internal slot of |Key| to {{KeyType/"public"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`X448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| is not empty
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-length-in-bits">length in bits</a> of |data| is not 448 then [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`X448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and that represents |data|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| to "`public`"
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |key|
+            </p>
+          </li>
+        </ol>
+      </section>
+
+      <section id="x448-operations-export-key">
+        <h5>Export Key</h5>
+        <ol>
+          <li>
+            <p>
+              Let |key| be the {{CryptoKey}} to be
+              exported.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the underlying cryptographic key material represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
+              cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an instance of the `subjectPublicKeyInfo`
+                      ASN.1 structure defined in [[RFC5280]]
+                      with the following properties:
+                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Set the |algorithm| field to an
+                          `AlgorithmIdentifier` ASN.1 type with the following
+                          properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| object identifier to the
+                              `id-X448` OID defined in [[RFC8410]].
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |subjectPublicKey| field to |keyData|.
+                        </p>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be a new {{ArrayBuffer}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and containing
+                      |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an instance of the `privateKeyInfo`
+                      ASN.1 structure defined in [[RFC5208]]
+                      with the following properties:
+                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Set the |version| field to `0`.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |privateKeyAlgorithm| field to a
+                          `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                          following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| object identifier to the
+                              `id-X448` OID defined in [[RFC8410]].
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |privateKey| field to the result of DER-encoding
+                          a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
+                          X448 private key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                          |key|
+                        </p>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be a new {{ArrayBuffer}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and containing
+                      |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      Let |jwk| be a new {{JsonWebKey}}
+                      dictionary.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `kty` attribute of |jwk| to
+                      "`OKP`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `crv` attribute of |jwk| to
+                      "`X448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                      definition in Section 2 of [[RFC8037]].
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>
+                        If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                        of |key| is {{KeyType/"private"}}
+                      </dt>
+                      <dd>
+                        Set the {{JsonWebKey/d}} attribute of |jwk| according to the
                         definition in Section 2 of [[RFC8037]].
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>
-                          If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                          of |key| is {{KeyType/"private"}}
-                        </dt>
-                        <dd>
-                          Set the {{JsonWebKey/d}} attribute of |jwk| according to the
-                          definition in Section 2 of [[RFC8037]].
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
-                        of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be the result of converting |jwk|
-                        to an ECMAScript Object, as defined by [[WebIDL]].
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>
-                  If |format| is {{KeyFormat/"raw"}}:
-                </dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a> representing the X448
-                        public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
-                        |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |result|.
-              </p>
-            </li>
-          </ol>
-        </dd>
-      </dl>
-    </section>
-  </section>
-
-  <section id="ed25519">
-    <h3>Ed25519</h3>
-    <section id="ed25519-description" class="informative">
-      <h4>Description</h4>
-      <p>
-        The "`Ed25519`" algorithm identifier is used to perform signing
-        and verification using the Ed25519 algorithm specified in
-        [[RFC8032]].
-      </p>
-    </section>
-    <section id="ed25519-registration">
-      <h4>Registration</h4>
-      <p>
-        The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
-        for this algorithm is "`Ed25519`".
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>sign</td>
-            <td>None</td>
-            <td>{{ArrayBuffer}}</td>
-          </tr>
-          <tr>
-            <td>verify</td>
-            <td>None</td>
-            <td>boolean</td>
-          </tr>
-          <tr>
-            <td>generateKey</td>
-            <td>None</td>
-            <td>{{CryptoKeyPair}}</td>
-          </tr>
-          <tr>
-            <td>importKey</td>
-            <td>None</td>
-            <td>{{CryptoKey}}</td>
-          </tr>
-          <tr>
-            <td>exportKey</td>
-            <td>None</td>
-            <td>object</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section id="ed25519-operations">
-      <h4>Operations</h4>
-      <dl>
-        <dt>Sign</dt>
-        <dd>
-          When signing, the following algorithm should be used:
-          <ol>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Perform the Ed25519 signing process, as specified in [[RFC8032]],
-                Section 5.1.6, with |message| as |M|,
-                using the Ed25519 private key associated with |key|.
-              </p>
-              <p class="issue" data-number="28">
-                Some implementations may (wish to) generate randomized signatures
-                as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
-                instead of deterministic signatures as per [[RFC8032]].
-              </p>
-            </li>
-            <li>
-              <p>
-                Return a new {{ArrayBuffer}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and containing the
-                bytes of the signature resulting from performing
-                the Ed25519 signing process.
-              </p>
-            </li>
-          </ol>
-        </dd>
-        <dt>Verify</dt>
-        <dd>
-          When verifying, the following algorithm should be used:
-          <ol>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the key data of |key| represents an invalid point or a small-order element
-                on the Elliptic Curve of Ed25519, return `false`.
-              </p>
-              <p class="issue" data-number="27">
-                Not all implementations perform this check.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the point R, encoded in the first half of |signature|,
-                represents an invalid point or a small-order element
-                on the Elliptic Curve of Ed25519, return `false`.
-              </p>
-              <p class="issue" data-number="27">
-                Not all implementations perform this check.
-              </p>
-            </li>
-            <li>
-              <p>
-                Perform the Ed25519 verification steps, as specified in [[RFC8032]],
-                Section 5.1.7, using the cofactorless (unbatched) equation,
-                `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|,
-                using the Ed25519 public key associated with |key|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |result| be a boolean with the value `true` if the signature is valid
-                and the value `false` otherwise.
-              </p>
-            </li>
-            <li>
-              <p>
-                Return |result|.
-              </p>
-            </li>
-          </ol>
-        </dd>
-        <dt>Generate Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                If |usages| contains a value which is not
-                one of "`sign`" or "`verify`",
-                then [= exception/throw =] a
-                {{SyntaxError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Generate an Ed25519 key pair, as defined in [[RFC8032]], section 5.1.5.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |algorithm| be a new {{KeyAlgorithm}} object.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{KeyAlgorithm/name}} attribute of
-                |algorithm| to "`Ed25519`".
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |publicKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the public key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |publicKey| to "`public`"
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |publicKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |publicKey| to true.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |publicKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
-                of |usages| and `[ "verify" ]`.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |privateKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the private key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |privateKey| to {{KeyType/"private"}}
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |privateKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |privateKey| to |extractable|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |privateKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
-                of |usages| and `[ "sign" ]`.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |result| be a new {{CryptoKeyPair}}
-                dictionary.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/publicKey}} attribute
-                of |result| to be |publicKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/privateKey}} attribute
-                of |result| to be |privateKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Return the result of converting |result| to an ECMAScript Object, as
-                defined by [[WebIDL]].
-              </p>
-            </li>
-          </ol>
-        </dd>
-
-        <dt>Import Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>Let |keyData| be the key data to be imported.</p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains a value which is not
-                        "`verify`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |spki| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `algorithm` AlgorithmIdentifier field of |spki| is
-                        not equal to the `id-Ed25519`
-                        object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the `algorithm`
-                        AlgorithmIdentifier field of |spki| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |publicKey| be the Ed25519 public key identified by
-                        the `subjectPublicKey` field of |spki|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents |publicKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains a value which is not
-                        "`sign`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |privateKeyInfo| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurs while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                        |privateKeyInfo| is not equal to the
-                        `id-Ed25519` object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                        of |privateKeyInfo| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
-                        algorithm, with |data| as the `privateKey` field
-                        of |privateKeyInfo|, |structure| as the ASN.1
-                        `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents the Ed25519 private key identified by |curvePrivateKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to {{KeyType/"private"}}
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <dl class="switch">
-                        <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                        <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                        <dt>Otherwise:</dt>
-                        <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/d}} field is present and |usages| contains
-                        a value which is not
-                        "`sign`", or,
-                        if the {{JsonWebKey/d}} field is not present and |usages| contains
-                        a value which is not
-                        "`verify`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/kty}} field of |jwk| is not
-                        "`OKP`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/crv}} field of |jwk| is not
-                        "`Ed25519`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/alg}} field of |jwk| is present and is
-                        not "`Ed25519`" or "`EdDSA`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                        not "`sig`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                        is invalid according to the requirements of JSON Web
-                        Key [[JWK]], or it does not contain all of the specified |usages|
-                        values,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/ext}} field of |jwk| is present and
-                        has the value false and |extractable| is true,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK private key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                Ed25519 private key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"private"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK public key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                Ed25519 public key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"public"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains a value which is not
-                        "`verify`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                     <li>
-                      <p>
-                        Let |data| be |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the <a data-cite="webcrypto#dfn-length-in-bits">length in bits</a> of |data| is not 256 then [= exception/throw =] a {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and that represents |data|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |key|
-              </p>
-            </li>
-          </ol>
-        </dd>
-
-        <dt>Export Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                Let |key| be the {{CryptoKey}} to be
-                exported.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
-                cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-              </p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `subjectPublicKeyInfo`
-                        ASN.1 structure defined in [[RFC5280]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |algorithm| field to an
-                            `AlgorithmIdentifier` ASN.1 type with the following
-                            properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-Ed25519` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |subjectPublicKey| field to |keyData|.
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `privateKeyInfo`
-                        ASN.1 structure defined in [[RFC5208]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |version| field to `0`.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKeyAlgorithm| field to a
-                            `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                            following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-Ed25519` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKey| field to the result of DER-encoding
-                            a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                            Ed25519 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
-                            |key|
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        Let |jwk| be a new {{JsonWebKey}}
-                        dictionary.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `kty` attribute of |jwk| to
-                        "`OKP`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `alg` attribute of |jwk| to
-                        "`Ed25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `crv` attribute of |jwk| to
-                        "`Ed25519`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{JsonWebKey/x}} attribute of |jwk| according to the
-                        definition in Section 2 of [[RFC8037]].
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>
-                          If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                          of |key| is {{KeyType/"private"}}
-                        </dt>
-                        <dd>
-                          Set the {{JsonWebKey/d}} attribute of |jwk| according to the
-                          definition in Section 2 of [[RFC8037]].
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
-                        of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be the result of converting |jwk|
-                        to an ECMAScript Object, as defined by [[WebIDL]].
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>
-                  If |format| is {{KeyFormat/"raw"}}:
-                </dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a> representing the Ed25519
-                        public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
-                        |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |result|.
-              </p>
-            </li>
-          </ol>
-        </dd>
-      </dl>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `ext` attribute of |jwk| to the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
+                      of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be the result of converting |jwk|
+                      to an ECMAScript Object, as defined by [[WebIDL]].
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>
+                If |format| is {{KeyFormat/"raw"}}:
+              </dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an <a data-cite="webcrypto#dfn-octet-string">octet string</a> representing the X448
+                      public key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                      |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be a new {{ArrayBuffer}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and containing
+                      |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
     </section>
   </section>
 
@@ -2698,15 +947,15 @@
     <section id="ed448-registration">
       <h4>Registration</h4>
       <p>
-        The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
+        The <a data-cite="webcrypto#recognized-algorithm-name">recognized algorithm name</a>
         for this algorithm is "`Ed448`".
       </p>
       <table>
         <thead>
           <tr>
-            <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
-            <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
+            <th><a data-cite="webcrypto#supported-operations">Operation</a></th>
+            <th><a data-cite="webcrypto#algorithm-specific-params">Parameters</a></th>
+            <th><a data-cite="webcrypto#algorithm-result">Result</a></th>
           </tr>
         </thead>
         <tbody>
@@ -2750,895 +999,889 @@ dictionary Ed448Params : Algorithm {
     </section>
     <section id="ed448-operations">
       <h4>Operations</h4>
-      <dl>
-        <dt>Sign</dt>
-        <dd>
-          When signing, the following algorithm should be used:
-          <ol>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |context| be the <a data-cite="WebCryptoAPI#concept-contents-of-arraybuffer">contents of</a>
-                the {{Ed448Params/context}} member of |normalizedAlgorithm|
-                or the empty octet string if the {{Ed448Params/context}} member of
-                |normalizedAlgorithm| is not present.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |context| has a length greater than 255 bytes,
-                then [= exception/throw =] an {{OperationError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Perform the Ed448 signing process, as specified in [[RFC8032]],
-                Section 5.2.6, with |message| as |M|
-                and |context| as |C|,
-                using the Ed448 private key associated with |key|.
-              </p>
-              <p class="issue" data-number="28">
-                Some implementations may (wish to) generate randomized signatures
-                as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
-                instead of deterministic signatures as per [[RFC8032]].
-              </p>
-            </li>
-            <li>
-              <p>
-                Return a new {{ArrayBuffer}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and containing the
-                bytes of the signature resulting from performing
-                the Ed448 signing process.
-              </p>
-            </li>
-          </ol>
-        </dd>
-        <dt>Verify</dt>
-        <dd>
-          When verifying, the following algorithm should be used:
-          <ol>
-            <li>
-              <p>
-                If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |context| be the <a data-cite="WebCryptoAPI#concept-contents-of-arraybuffer">contents of</a>
-                the {{Ed448Params/context}} member of |normalizedAlgorithm|
-                or the empty octet string if the {{Ed448Params/context}} member of
-                |normalizedAlgorithm| is not present.
-              </p>
-            </li>
-            <li>
-              <p>
-                If |context| has a length greater than 255 bytes,
-                then [= exception/throw =] an {{OperationError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the key data of |key| represents an invalid point or a small-order element
-                on the Elliptic Curve of Ed448, return `false`.
-              </p>
-              <p class="issue" data-number="27">
-                Not all implementations perform this check.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the point R, encoded in the first half of |signature|,
-                represents an invalid point or a small-order element
-                on the Elliptic Curve of Ed448, return `false`.
-              </p>
-              <p class="issue" data-number="27">
-                Not all implementations perform this check.
-              </p>
-            </li>
-            <li>
-              <p>
-                Perform the Ed448 verification steps, as specified in [[RFC8032]],
-                Section 5.2.7, using the cofactorless (unbatched) equation,
-                `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|
-                and |context| as |C|,
-                using the Ed448 public key associated with |key|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |result| be a boolean with the value `true` if the signature is valid
-                and the value `false` otherwise.
-              </p>
-            </li>
-            <li>
-              <p>
-                Return |result|.
-              </p>
-            </li>
-          </ol>
-        </dd>
-        <dt>Generate Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                If |usages| contains a value which is not
-                one of "`sign`" or "`verify`",
-                then [= exception/throw =] a
-                {{SyntaxError}}.
-              </p>
-            </li>
-            <li>
-              <p>
-                Generate an Ed448 key pair, as defined in [[RFC8032]], section 5.1.5.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |algorithm| be a new {{KeyAlgorithm}} object.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{KeyAlgorithm/name}} attribute of
-                |algorithm| to "`Ed448`".
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |publicKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the public key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |publicKey| to "`public`"
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |publicKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |publicKey| to true.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |publicKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
-                of |usages| and `[ "verify" ]`.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |privateKey| be a new {{CryptoKey}} associated with the
-                [= relevant global object =]
-                of `this` [[HTML]], and
-                representing the private key of the generated key pair.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
-                |privateKey| to {{KeyType/"private"}}
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
-                slot of |privateKey| to |algorithm|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
-                slot of |privateKey| to |extractable|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                |privateKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
-                of |usages| and `[ "sign" ]`.
-              </p>
-            </li>
-            <li>
-              <p>
-                Let |result| be a new {{CryptoKeyPair}}
-                dictionary.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/publicKey}} attribute
-                of |result| to be |publicKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Set the {{CryptoKeyPair/privateKey}} attribute
-                of |result| to be |privateKey|.
-              </p>
-            </li>
-            <li>
-              <p>
-                Return the result of converting |result| to an ECMAScript Object, as
-                defined by [[WebIDL]].
-              </p>
-            </li>
-          </ol>
-        </dd>
-
-        <dt>Import Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>Let |keyData| be the key data to be imported.</p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains a value which is not
-                        "`verify`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |spki| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `algorithm` AlgorithmIdentifier field of |spki| is
-                        not equal to the `id-Ed448`
-                        object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the `algorithm`
-                        AlgorithmIdentifier field of |spki| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |publicKey| be the Ed448 public key identified by
-                        the `subjectPublicKey` field of |spki|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents |publicKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains a value which is not
-                        "`sign`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |privateKeyInfo| be the result of running the
-                        <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
-                        algorithm over |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurs while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `algorithm` object identifier field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                        |privateKeyInfo| is not equal to the
-                        `id-Ed448` object identifier defined in [[RFC8410]],
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the `parameters` field of the
-                        `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                        of |privateKeyInfo| is present,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
-                        algorithm, with |data| as the `privateKey` field
-                        of |privateKeyInfo|, |structure| as the ASN.1
-                        `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If an error occurred while parsing,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and
-                        that represents the Ed448 private key identified by |curvePrivateKey|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to {{KeyType/"private"}}
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <dl class="switch">
-                        <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                        <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                        <dt>Otherwise:</dt>
-                        <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/d}} field is present and |usages| contains
-                        a value which is not
-                        "`sign`", or,
-                        if the {{JsonWebKey/d}} field is not present and |usages| contains
-                        a value which is not
-                        "`verify`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/kty}} field of |jwk| is not
-                        "`OKP`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/crv}} field of |jwk| is not
-                        "`Ed448`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/alg}} field of |jwk| is present and is
-                        not "`Ed448`" or "`EdDSA`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                        not "`sig`",
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                        is invalid according to the requirements of JSON Web
-                        Key [[JWK]], or it does not contain all of the specified |usages|
-                        values,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the {{JsonWebKey/ext}} field of |jwk| is present and
-                        has the value false and |extractable| is true,
-                        then [= exception/throw =] a
-                        {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK private key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                Ed448 private key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"private"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          <ol>
-                            <li>
-                              <p>
-                                If |jwk| does not meet the requirements of
-                                the JWK public key format described in Section 2
-                                of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Let |key| be a new {{CryptoKey}} object that represents the
-                                Ed448 public key identified by interpreting
-                                |jwk| according to Section 2 of [[RFC8037]].
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
-                                internal slot of |Key| to {{KeyType/"public"}}.
-                              </p>
-                            </li>
-                          </ol>
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If |usages| contains a value which is not
-                        "`verify`"
-                        then [= exception/throw =] a
-                        {{SyntaxError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be |keyData|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        If the <a data-cite="webcrypto#dfn-length-in-bits">length in bits</a> of |data| is not 448 then [= exception/throw =] a {{DataError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |algorithm| be a new {{KeyAlgorithm}} object.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{KeyAlgorithm/name}} attribute of
-                        |algorithm| to "`Ed448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |key| be a new {{CryptoKey}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and that represents |data|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| to "`public`"
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
-                        internal slot of |key| to |algorithm|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |key|
-              </p>
-            </li>
-          </ol>
-        </dd>
-
-        <dt>Export Key</dt>
-        <dd>
-          <ol>
-            <li>
-              <p>
-                Let |key| be the {{CryptoKey}} to be
-                exported.
-              </p>
-            </li>
-            <li>
-              <p>
-                If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
-                cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-              </p>
-            </li>
-            <li>
-              <dl class="switch">
-                <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `subjectPublicKeyInfo`
-                        ASN.1 structure defined in [[RFC5280]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |algorithm| field to an
-                            `AlgorithmIdentifier` ASN.1 type with the following
-                            properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-Ed448` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |subjectPublicKey| field to |keyData|.
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an instance of the `privateKeyInfo`
-                        ASN.1 structure defined in [[RFC5208]]
-                        with the following properties:
-                      </p>
-                      <ul>
-                        <li>
-                          <p>
-                            Set the |version| field to `0`.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKeyAlgorithm| field to a
-                            `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                            following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| object identifier to the
-                                `id-Ed448` OID defined in [[RFC8410]].
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |privateKey| field to the result of DER-encoding
-                            a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                            Ed448 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
-                            |key|
-                          </p>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        Let |jwk| be a new {{JsonWebKey}}
-                        dictionary.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `kty` attribute of |jwk| to
-                        "`OKP`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `alg` attribute of |jwk| to
-                        "`Ed448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `crv` attribute of |jwk| to
-                        "`Ed448`".
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+      <section id="ed448-operations-sign">
+        <h5>Sign</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |context| be the <a data-cite="webcrypto#concept-contents-of-arraybuffer">contents of</a>
+              the {{Ed448Params/context}} member of |normalizedAlgorithm|
+              or the empty octet string if the {{Ed448Params/context}} member of
+              |normalizedAlgorithm| is not present.
+            </p>
+          </li>
+          <li>
+            <p>
+              If |context| has a length greater than 255 bytes,
+              then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Perform the Ed448 signing process, as specified in [[RFC8032]],
+              Section 5.2.6, with |message| as |M|
+              and |context| as |C|,
+              using the Ed448 private key associated with |key|.
+            </p>
+            <p class="issue" data-number="28">
+              Some implementations may (wish to) generate randomized signatures
+              as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
+              instead of deterministic signatures as per [[RFC8032]].
+            </p>
+          </li>
+          <li>
+            <p>
+              Return a new {{ArrayBuffer}} associated with the
+              [= relevant global object =]
+              of `this` [[HTML]], and containing the
+              bytes of the signature resulting from performing
+              the Ed448 signing process.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="ed448-operations-verify">
+        <h5>Verify</h5>
+        <ol>
+          <li>
+            <p>
+              If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |context| be the <a data-cite="webcrypto#concept-contents-of-arraybuffer">contents of</a>
+              the {{Ed448Params/context}} member of |normalizedAlgorithm|
+              or the empty octet string if the {{Ed448Params/context}} member of
+              |normalizedAlgorithm| is not present.
+            </p>
+          </li>
+          <li>
+            <p>
+              If |context| has a length greater than 255 bytes,
+              then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the key data of |key| represents an invalid point or a small-order element
+              on the Elliptic Curve of Ed448, return `false`.
+            </p>
+            <p class="issue" data-number="27">
+              Not all implementations perform this check.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the point R, encoded in the first half of |signature|,
+              represents an invalid point or a small-order element
+              on the Elliptic Curve of Ed448, return `false`.
+            </p>
+            <p class="issue" data-number="27">
+              Not all implementations perform this check.
+            </p>
+          </li>
+          <li>
+            <p>
+              Perform the Ed448 verification steps, as specified in [[RFC8032]],
+              Section 5.2.7, using the cofactorless (unbatched) equation,
+              `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|
+              and |context| as |C|,
+              using the Ed448 public key associated with |key|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a boolean with the value `true` if the signature is valid
+              and the value `false` otherwise.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="ed448-operations-generate-key">
+        <h5>Generate Key</h5>
+        <ol>
+          <li>
+            <p>
+              If |usages| contains a value which is not
+              one of "`sign`" or "`verify`",
+              then [= exception/throw =] a
+              {{SyntaxError}}.
+            </p>
+          </li>
+          <li>
+            <p>
+              Generate an Ed448 key pair, as defined in [[RFC8032]], section 5.1.5.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |algorithm| be a new {{KeyAlgorithm}} object.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{KeyAlgorithm/name}} attribute of
+              |algorithm| to "`Ed448`".
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |publicKey| be a new {{CryptoKey}} associated with the
+              [= relevant global object =]
+              of `this` [[HTML]], and
+              representing the public key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |publicKey| to "`public`"
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+              slot of |publicKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+              slot of |publicKey| to true.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+              |publicKey| to be the <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a>
+              of |usages| and `[ "verify" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |privateKey| be a new {{CryptoKey}} associated with the
+              [= relevant global object =]
+              of `this` [[HTML]], and
+              representing the private key of the generated key pair.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+              |privateKey| to {{KeyType/"private"}}
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+              slot of |privateKey| to |algorithm|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+              slot of |privateKey| to |extractable|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+              |privateKey| to be the <a data-cite="webcrypto#concept-usage-intersection">usage intersection</a>
+              of |usages| and `[ "sign" ]`.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |result| be a new {{CryptoKeyPair}}
+              dictionary.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/publicKey}} attribute
+              of |result| to be |publicKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Set the {{CryptoKeyPair/privateKey}} attribute
+              of |result| to be |privateKey|.
+            </p>
+          </li>
+          <li>
+            <p>
+              Return the result of converting |result| to an ECMAScript Object, as
+              defined by [[WebIDL]].
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="ed448-operations-import-key">
+        <h5>Import Key</h5>
+        <ol>
+          <li>
+            <p>Let |keyData| be the key data to be imported.</p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains a value which is not
+                      "`verify`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |spki| be the result of running the
+                      <a data-cite="webcrypto#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                      algorithm over |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurred while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `algorithm` object identifier field of the
+                      `algorithm` AlgorithmIdentifier field of |spki| is
+                      not equal to the `id-Ed448`
+                      object identifier defined in [[RFC8410]],
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `parameters` field of the `algorithm`
+                      AlgorithmIdentifier field of |spki| is present,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |publicKey| be the Ed448 public key identified by
+                      the `subjectPublicKey` field of |spki|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and
+                      that represents |publicKey|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| to "`public`"
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`Ed448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains a value which is not
+                      "`sign`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |privateKeyInfo| be the result of running the
+                      <a data-cite="webcrypto#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
+                      algorithm over |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurs while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `algorithm` object identifier field of the
+                      `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                      |privateKeyInfo| is not equal to the
+                      `id-Ed448` object identifier defined in [[RFC8410]],
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the `parameters` field of the
+                      `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                      of |privateKeyInfo| is present,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |curvePrivateKey| be the result of performing the <a data-cite="webcrypto#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
+                      algorithm, with |data| as the `privateKey` field
+                      of |privateKeyInfo|, |structure| as the ASN.1
+                      `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If an error occurred while parsing,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and
+                      that represents the Ed448 private key identified by |curvePrivateKey|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| to {{KeyType/"private"}}
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`Ed448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <dl class="switch">
+                      <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                      <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                      <dt>Otherwise:</dt>
+                      <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/d}} field is present and |usages| contains
+                      a value which is not
+                      "`sign`", or,
+                      if the {{JsonWebKey/d}} field is not present and |usages| contains
+                      a value which is not
+                      "`verify`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/kty}} field of |jwk| is not
+                      "`OKP`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/crv}} field of |jwk| is not
+                      "`Ed448`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/alg}} field of |jwk| is present and is
+                      not "`Ed448`" or "`EdDSA`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                      not "`sig`",
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                      is invalid according to the requirements of JSON Web
+                      Key [[JWK]], or it does not contain all of the specified |usages|
+                      values,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the {{JsonWebKey/ext}} field of |jwk| is present and
+                      has the value false and |extractable| is true,
+                      then [= exception/throw =] a
+                      {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If |jwk| does not meet the requirements of
+                              the JWK private key format described in Section 2
+                              of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              Ed448 private key identified by interpreting
+                              |jwk| according to Section 2 of [[RFC8037]].
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a>
+                              internal slot of |Key| to {{KeyType/"private"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        <ol>
+                          <li>
+                            <p>
+                              If |jwk| does not meet the requirements of
+                              the JWK public key format described in Section 2
+                              of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Let |key| be a new {{CryptoKey}} object that represents the
+                              Ed448 public key identified by interpreting
+                              |jwk| according to Section 2 of [[RFC8037]].
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a>
+                              internal slot of |Key| to {{KeyType/"public"}}.
+                            </p>
+                          </li>
+                        </ol>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`Ed448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If |usages| contains a value which is not
+                      "`verify`"
+                      then [= exception/throw =] a
+                      {{SyntaxError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be |keyData|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-length-in-bits">length in bits</a> of |data| is not 448 then [= exception/throw =] a {{DataError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |algorithm| be a new {{KeyAlgorithm}} object.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{KeyAlgorithm/name}} attribute of
+                      |algorithm| to "`Ed448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |key| be a new {{CryptoKey}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and that represents |data|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| to "`public`"
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the <a data-cite="webcrypto#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                      internal slot of |key| to |algorithm|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |key|
+            </p>
+          </li>
+        </ol>
+      </section>
+      <section id="ed448-operations-export-key">
+        <h5>Export Key</h5>
+        <ol>
+          <li>
+            <p>
+              Let |key| be the {{CryptoKey}} to be
+              exported.
+            </p>
+          </li>
+          <li>
+            <p>
+              If the underlying cryptographic key material represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
+              cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+            </p>
+          </li>
+          <li>
+            <dl class="switch">
+              <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an instance of the `subjectPublicKeyInfo`
+                      ASN.1 structure defined in [[RFC5280]]
+                      with the following properties:
+                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Set the |algorithm| field to an
+                          `AlgorithmIdentifier` ASN.1 type with the following
+                          properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| object identifier to the
+                              `id-Ed448` OID defined in [[RFC8410]].
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |subjectPublicKey| field to |keyData|.
+                        </p>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be a new {{ArrayBuffer}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and containing
+                      |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an instance of the `privateKeyInfo`
+                      ASN.1 structure defined in [[RFC5208]]
+                      with the following properties:
+                    </p>
+                    <ul>
+                      <li>
+                        <p>
+                          Set the |version| field to `0`.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |privateKeyAlgorithm| field to a
+                          `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                          following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| object identifier to the
+                              `id-Ed448` OID defined in [[RFC8410]].
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |privateKey| field to the result of DER-encoding
+                          a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
+                          Ed448 private key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                          |key|
+                        </p>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be a new {{ArrayBuffer}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and containing
+                      |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      Let |jwk| be a new {{JsonWebKey}}
+                      dictionary.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `kty` attribute of |jwk| to
+                      "`OKP`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `alg` attribute of |jwk| to
+                      "`Ed448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `crv` attribute of |jwk| to
+                      "`Ed448`".
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                      definition in Section 2 of [[RFC8037]].
+                    </p>
+                  </li>
+                  <li>
+                    <dl class="switch">
+                      <dt>
+                        If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                        of |key| is {{KeyType/"private"}}
+                      </dt>
+                      <dd>
+                        Set the {{JsonWebKey/d}} attribute of |jwk| according to the
                         definition in Section 2 of [[RFC8037]].
-                      </p>
-                    </li>
-                    <li>
-                      <dl class="switch">
-                        <dt>
-                          If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                          of |key| is {{KeyType/"private"}}
-                        </dt>
-                        <dd>
-                          Set the {{JsonWebKey/d}} attribute of |jwk| according to the
-                          definition in Section 2 of [[RFC8037]].
-                        </dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
-                        of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be the result of converting |jwk|
-                        to an ECMAScript Object, as defined by [[WebIDL]].
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>
-                  If |format| is {{KeyFormat/"raw"}}:
-                </dt>
-                <dd>
-                  <ol>
-                    <li>
-                      <p>
-                        If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
-                        of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a>
-                        representing the Ed448 public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a>
-                        internal slot of |key|.
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        Let |result| be a new {{ArrayBuffer}} associated with the
-                        [= relevant global object =]
-                        of `this` [[HTML]], and containing
-                        |data|.
-                      </p>
-                    </li>
-                  </ol>
-                </dd>
-                <dt>Otherwise:</dt>
-                <dd>
-                  <p>
-                    [= exception/throw =] a
-                    {{NotSupportedError}}.
-                  </p>
-                </dd>
-              </dl>
-            </li>
-            <li>
-              <p>
-                Return |result|.
-              </p>
-            </li>
-          </ol>
-        </dd>
-      </dl>
+                      </dd>
+                    </dl>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Set the `ext` attribute of |jwk| to the <a data-cite="webcrypto#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
+                      of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be the result of converting |jwk|
+                      to an ECMAScript Object, as defined by [[WebIDL]].
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>
+                If |format| is {{KeyFormat/"raw"}}:
+              </dt>
+              <dd>
+                <ol>
+                  <li>
+                    <p>
+                      If the <a data-cite="webcrypto#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                      of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |data| be an <a data-cite="webcrypto#dfn-octet-string">octet string</a>
+                      representing the Ed448 public key represented by the <a data-cite="webcrypto#dfn-CryptoKey-slot-handle">[[\handle]]</a>
+                      internal slot of |key|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      Let |result| be a new {{ArrayBuffer}} associated with the
+                      [= relevant global object =]
+                      of `this` [[HTML]], and containing
+                      |data|.
+                    </p>
+                  </li>
+                </ol>
+              </dd>
+              <dt>Otherwise:</dt>
+              <dd>
+                <p>
+                  [= exception/throw =] a
+                  {{NotSupportedError}}.
+                </p>
+              </dd>
+            </dl>
+          </li>
+          <li>
+            <p>
+              Return |result|.
+            </p>
+          </li>
+        </ol>
+      </section>
     </section>
   </section>
 
   <section>
     <h2>Usage Example</h2>
     <p>
-      This example generates two X25519 key pairs, one for Alice and one for Bob, performs
+      This example generates two X448 key pairs, one for Alice and one for Bob, performs
       a key agreement between them, derives a 256-bit AES-GCM key from the result using
       HKDF with SHA-256, and encrypts and decrypts some data with it.
     </p>
-    <pre class="example js" title="X25519 key agreement">
+    <pre class="example js" title="X448 key agreement">
       // Generate a key pair for Alice.
-      const alice_x25519_key = await crypto.subtle.generateKey('X25519', false /* extractable */, ['deriveKey']);
-      const alice_private_key = alice_x25519_key.privateKey;
+      const alice_x448_key = await crypto.subtle.generateKey('X448', false /* extractable */, ['deriveKey']);
+      const alice_private_key = alice_x448_key.privateKey;
 
       // Normally, the public key would be sent by Bob to Alice in advance over some authenticated channel.
       // In this example, we'll generate another key pair and use its public key instead.
-      const bob_x25519_key = await crypto.subtle.generateKey('X25519', false /* extractable */, ['deriveKey']);
-      const bob_public_key = bob_x25519_key.publicKey;
+      const bob_x448_key = await crypto.subtle.generateKey('X448', false /* extractable */, ['deriveKey']);
+      const bob_public_key = bob_x448_key.publicKey;
 
       // Perform the key agreement.
-      const alice_x25519_params = { name: 'X25519', public: bob_public_key };
-      const alice_shared_key = await crypto.subtle.deriveKey(alice_x25519_params, alice_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
+      const alice_x448_params = { name: 'X448', public: bob_public_key };
+      const alice_shared_key = await crypto.subtle.deriveKey(alice_x448_params, alice_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
 
       // Derive a symmetric key from the result.
       const salt = crypto.getRandomValues(new Uint8Array(32));
-      const info = new TextEncoder().encode('X25519 key agreement for an AES-GCM-256 key');
+      const info = new TextEncoder().encode('X448 key agreement for an AES-GCM-256 key');
       const hkdf_params = { name: 'HKDF', hash: 'SHA-256', salt, info };
       const gcm_params = { name: 'AES-GCM', length: 256 };
       const alice_symmetric_key = await crypto.subtle.deriveKey(hkdf_params, alice_shared_key, gcm_params, false /* extractable */, ['encrypt', 'decrypt']);
@@ -3650,10 +1893,10 @@ dictionary Ed448Params : Algorithm {
 
       // On Bob's side, Alice's public key and Bob's private key are used, instead.
       // To get the same result, Alice and Bob must agree on using the same salt and info.
-      const alice_public_key = alice_x25519_key.publicKey;
-      const bob_private_key = bob_x25519_key.privateKey;
-      const bob_x25519_params = { name: 'X25519', public: alice_public_key };
-      const bob_shared_key = await crypto.subtle.deriveKey(bob_x25519_params, bob_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
+      const alice_public_key = alice_x448_key.publicKey;
+      const bob_private_key = bob_x448_key.privateKey;
+      const bob_x448_params = { name: 'X448', public: alice_public_key };
+      const bob_shared_key = await crypto.subtle.deriveKey(bob_x448_params, bob_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
       const bob_symmetric_key = await crypto.subtle.deriveKey(hkdf_params, bob_shared_key, gcm_params, false /* extractable */, ['encrypt', 'decrypt']);
 
       // On Bob's side, the data can be decrypted.
@@ -3681,38 +1924,12 @@ dictionary Ed448Params : Algorithm {
           <td>
 <pre class=js>
 { kty: "OKP",
-  crv: "X25519" }
-</pre>
-          </td>
-          <td>
-<pre class=js>
-{ name: "X25519" }
-</pre>
-          </td>
-        </tr>
-        <tr>
-          <td>
-<pre class=js>
-{ kty: "OKP",
   crv: "X448" }
 </pre>
           </td>
           <td>
 <pre class=js>
 { name: "X448" }
-</pre>
-          </td>
-        </tr>
-          <td>
-<pre class=js>
-{ kty: "OKP",
-  crv: "Ed25519",
-  alg: "Ed25519" }
-</pre>
-          </td>
-          <td>
-<pre class=js>
-{ name: "Ed25519" }
 </pre>
           </td>
         </tr>
@@ -3750,30 +1967,10 @@ dictionary Ed448Params : Algorithm {
       </thead>
       <tbody>
         <tr>
-          <td>id-X25519 (1.3.101.110)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`X25519`"
-          </td>
-          <td>
-            [[RFC8410]]
-          </td>
-        </tr>
-        <tr>
           <td>id-X448 (1.3.101.111)</td>
           <td>BIT STRING</td>
           <td>
             "`X448`"
-          </td>
-          <td>
-            [[RFC8410]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-Ed25519 (1.3.101.112)</td>
-          <td>BIT STRING</td>
-          <td>
-            "`Ed25519`"
           </td>
           <td>
             [[RFC8410]]
@@ -3809,30 +2006,10 @@ dictionary Ed448Params : Algorithm {
       </thead>
       <tbody>
         <tr>
-          <td>id-X25519 (1.3.101.110)</td>
-          <td>CurvePrivateKey</td>
-          <td>
-            "`X25519`"
-          </td>
-          <td>
-            [[RFC8410]]
-          </td>
-        </tr>
-        <tr>
           <td>id-X448 (1.3.101.111)</td>
           <td>CurvePrivateKey</td>
           <td>
             "`X448`"
-          </td>
-          <td>
-            [[RFC8410]]
-          </td>
-        </tr>
-        <tr>
-          <td>id-Ed25519 (1.3.101.112)</td>
-          <td>CurvePrivateKey</td>
-          <td>
-            "`Ed25519`"
           </td>
           <td>
             [[RFC8410]]


### PR DESCRIPTION
closes #36 and introduces sections for individual operations


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto-secure-curves/pull/37.html" title="Last updated on Jul 31, 2025, 1:24 PM UTC (4e144a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webcrypto-secure-curves/37/fdfd829...panva:4e144a2.html" title="Last updated on Jul 31, 2025, 1:24 PM UTC (4e144a2)">Diff</a>